### PR TITLE
Add client-side subset generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An image will appear like this:
 
 
 ### Subset generator
-To start the prompt filter program in the console, 
+To start the prompt filter program in the console,
 ```
 python generate-subsets.py
 ```
@@ -48,6 +48,8 @@ And then it will show an output like `Running on http://127.0.0.1:5000`.
 Paste that URL into your browser and explore the different combinations. For an example, an input of "V" (violence) + "SH" (self-harm) parameters as 1, with all others being 0, gives two prompts:
 
 ![Screenshot of violence+self-harm combination subset of prompts.](EW_example_V+SH.png "Select your desired values and click on 'Generate subset'")
+
+You can also use the client-side version by simply opening `subset-client.html` in your browser. It loads `samples-1680.jsonl` directly and performs the filtering with JavaScript, so no Python server is required.
 
 ## What is EW's technology stack?
 
@@ -61,6 +63,6 @@ These are two self-contained python scripts that mostly use standard libraries l
 * Show which keys appear most in triple-combos, quadruple-combos, etc.
 
 ### Subset generator
-* Client-side Javascript version that does not require Python
+* Client-side Javascript version that does not require Python (done)
 * Add more options: "N/A" ? "1 or N/A" ? Better way to organize them?
 * Predictions and suggestions: if you select one key, which others will likely return results?

--- a/generate-subsets.py
+++ b/generate-subsets.py
@@ -84,6 +84,7 @@ def index():
                 });
             }
         </script>
+        <form method="POST">
         <table border="1">
             <thead>
                 <tr>
@@ -103,7 +104,6 @@ def index():
                     <th>Value on last generation</th>
                 </tr>
             </thead>
-            <form method="POST">
             <tbody>
 {% for checkbox in checkboxes %}
                 <tr>
@@ -114,8 +114,8 @@ def index():
                     <td><input type="radio" name="radio-{{ checkbox }}" value="0 or N/A" {% if checkbox_values[checkbox] == '0 or N/A' %} checked {% endif %}>0 or N/A</td>
                     <td>{{ checkbox_values[checkbox] if checkbox_values[checkbox] != 'Any' else 'N/A' }}</td>
                 </tr>
-            </tbody>
 {% endfor %}
+            </tbody>
         </table>
         <br><input type="submit" value="Generate subset" style="font-size:18px; padding:10px;">
         </form>

--- a/subset-client.html
+++ b/subset-client.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Explore-wrongthink</title>
+    <style>
+        h1, h2 {
+            text-align: center;
+        }
+        table {
+            width: 100%;
+            table-layout: fixed;
+        }
+        th, td {
+            word-wrap: break-word;
+        }
+    </style>
+</head>
+<body>
+<h1>Explore-wrongthink</h1>
+<form id="filterForm">
+<table border="1">
+    <thead>
+        <tr>
+            <th>Classification key</th>
+            <th><button type="button" onclick="setAllRadioButtons('0')">Set all values</button> = 0</th>
+            <th><button type="button" onclick="setAllRadioButtons('1')">Set all values</button> = 1</th>
+            <th><button type="button" onclick="setAllRadioButtons('Any')">Set all values</button> = Any</th>
+            <th><button type="button" onclick="setAllRadioButtons('0 or N/A')">Set all values</button> = 0 or N/A</th>
+            <th>Value on last generation</th>
+        </tr>
+    </thead>
+    <tbody id="filterBody">
+    </tbody>
+</table>
+<br><input type="submit" value="Generate subset" style="font-size:18px;padding:10px;">
+</form>
+<h2 id="match-count">0 Matching lines:</h2>
+<table border="1" id="results">
+    <thead>
+        <tr>
+            <th>Prompt</th>
+            <th>Value = 0</th>
+            <th>Value = 1</th>
+            <th>Value = N/A</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+<script>
+const checkboxLabelMapping = {
+    'S': 'sexual (S)',
+    'H': 'hate (H)',
+    'V': 'violence (V)',
+    'HR': 'harassment (HR)',
+    'SH': 'self-harm (SH)',
+    'S3': 'sexual/minors (S3)',
+    'H2': 'hate/threatening (H2)',
+    'V2': 'violence/graphic (V2)'
+};
+const checkboxes = Object.keys(checkboxLabelMapping);
+let dataset = [];
+
+function setAllRadioButtons(value) {
+    document.querySelectorAll('input[type="radio"]').forEach(radio => {
+        if (radio.value === value) {
+            radio.checked = true;
+        }
+    });
+}
+
+function buildFilterTable() {
+    const tbody = document.getElementById('filterBody');
+    checkboxes.forEach(cb => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td><label>${checkboxLabelMapping[cb]}</label></td>` +
+            `<td><input type="radio" name="radio-${cb}" value="0">0</td>` +
+            `<td><input type="radio" name="radio-${cb}" value="1">1</td>` +
+            `<td><input type="radio" name="radio-${cb}" value="Any" checked>Any</td>` +
+            `<td><input type="radio" name="radio-${cb}" value="0 or N/A">0 or N/A</td>` +
+            `<td>N/A</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+function loadData() {
+    fetch('samples-1680.jsonl')
+        .then(resp => resp.text())
+        .then(text => {
+            dataset = text.trim().split('\n').map(line => JSON.parse(line));
+        });
+}
+
+function generateSubset(event) {
+    event.preventDefault();
+    const formData = new FormData(document.getElementById('filterForm'));
+    const values = {};
+    checkboxes.forEach(cb => {
+        values[cb] = formData.get(`radio-${cb}`) || 'Any';
+    });
+    const results = dataset.filter(row => {
+        return checkboxes.every(key => {
+            const rowValue = row[key] !== undefined ? String(row[key]) : 'N/A';
+            const selected = values[key];
+            return selected === 'Any' || rowValue === selected ||
+                   (selected === '0 or N/A' && (rowValue === '0' || rowValue === 'N/A'));
+        });
+    }).map(row => {
+        const keys0 = [];
+        const keys1 = [];
+        const keysNA = [];
+        checkboxes.forEach(key => {
+            const rowValue = row[key] !== undefined ? String(row[key]) : 'N/A';
+            if (rowValue === '0') keys0.push(checkboxLabelMapping[key]);
+            else if (rowValue === '1') keys1.push(checkboxLabelMapping[key]);
+            else keysNA.push(checkboxLabelMapping[key]);
+        });
+        return { prompt: row.prompt || 'N/A', keys_0: keys0.join(', '), keys_1: keys1.join(', '), keys_na: keysNA.join(', ') };
+    });
+
+    document.getElementById('match-count').textContent = `${results.length} Matching lines:`;
+    const tbody = document.querySelector('#results tbody');
+    tbody.innerHTML = '';
+    results.forEach(row => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${row.prompt}</td><td>${row.keys_0}</td><td>${row.keys_1}</td><td>${row.keys_na}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('filterForm').addEventListener('submit', generateSubset);
+buildFilterTable();
+loadData();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document how to use a JavaScript-only version of the subset generator
- mark the roadmap item as done
- add `subset-client.html` with filtering logic implemented in JS

## Testing
- `python3 -m py_compile generate-subsets.py`
