### PR TITLE
Add dataset.js converter and update client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+dataset.js

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Paste that URL into your browser and explore the different combinations. For an 
 
 ![Screenshot of violence+self-harm combination subset of prompts.](EW_example_V+SH.png "Select your desired values and click on 'Generate subset'")
 
-You can also use the client-side version. Open `subset-client.html` in your browser and it will load `samples-1680.jsonl` directly to perform the filtering with JavaScript. Some browsers block fetching local files, so if no data appears, start a simple HTTP server (e.g. run `python3 -m http.server`) and visit `http://localhost:8000/subset-client.html` instead.
+You can also use the client-side version. Run `python scripts/jsonl_to_js.py` to
+create `dataset.js`, then open `subset-client.html` in your browser. The page
+uses this generated file for filtering. Some browsers block loading local files,
+so if nothing appears, start a simple HTTP server (e.g. run `python3 -m
+http.server`) and visit `http://localhost:8000/subset-client.html` instead.
 
 ### Category analysis
 To compare how frequently each category appears and which combinations are most common, run

--- a/scripts/jsonl_to_js.py
+++ b/scripts/jsonl_to_js.py
@@ -1,0 +1,25 @@
+import json
+import argparse
+
+
+def main(in_path, out_path):
+    with open(in_path, "r", encoding="utf-8") as f:
+        data = [json.loads(line) for line in f]
+
+    with open(out_path, "w", encoding="utf-8") as out:
+        out.write("const dataset = ")
+        json.dump(data, out, ensure_ascii=False, indent=2)
+        out.write(";\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert JSONL to dataset.js")
+    parser.add_argument(
+        "--input", default="samples-1680.jsonl",
+        help="Path to JSONL file")
+    parser.add_argument(
+        "--output", default="dataset.js",
+        help="Output JS file")
+    args = parser.parse_args()
+    main(args.input, args.output)

--- a/subset-client.html
+++ b/subset-client.html
@@ -48,6 +48,7 @@
     <tbody>
     </tbody>
 </table>
+<script src="dataset.js"></script>
 <script>
 const checkboxLabelMapping = {
     'S': 'sexual (S)',
@@ -60,7 +61,6 @@ const checkboxLabelMapping = {
     'V2': 'violence/graphic (V2)'
 };
 const checkboxes = Object.keys(checkboxLabelMapping);
-let dataset = [];
 
 function setAllRadioButtons(value) {
     document.querySelectorAll('input[type="radio"]').forEach(radio => {
@@ -84,24 +84,6 @@ function buildFilterTable() {
     });
 }
 
-function loadData() {
-    return fetch('samples-1680.jsonl')
-        .then(resp => {
-            if (!resp.ok) throw new Error('Network response was not ok');
-            return resp.text();
-        })
-        .then(text => {
-            dataset = text.trim().split('\n').map(line => JSON.parse(line));
-        })
-        .catch(err => {
-            const msg = document.createElement('div');
-            msg.style.color = 'red';
-            msg.textContent = 'Failed to load samples-1680.jsonl. ' +
-                'Try running a local HTTP server (e.g. "python3 -m http.server") and open this file via http://localhost:8000/.';
-            document.body.insertBefore(msg, document.body.firstChild);
-            console.error('Error loading data:', err);
-        });
-}
 
 function generateSubset(event) {
     event.preventDefault();
@@ -142,7 +124,6 @@ function generateSubset(event) {
 
 document.getElementById('filterForm').addEventListener('submit', generateSubset);
 buildFilterTable();
-loadData();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `scripts/jsonl_to_js.py` to convert the JSONL dataset into a JS file
- update client HTML to use the generated `dataset.js`
- document dataset conversion step in the README
- ignore `dataset.js` so repo size stays small

## Testing
- `python -m py_compile scripts/jsonl_to_js.py`
- `python scripts/jsonl_to_js.py --input samples-1680.jsonl --output dataset.js`
