### PR TITLE
Fix missing charts due to loader elements

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -22,3 +22,22 @@ canvas {
         font-size: 0.85rem;
     }
 }
+
+/* Loader styles for dataset loading indicator */
+#loading {
+    text-align: center;
+    margin: 20px;
+}
+.spinner {
+    border: 8px solid #f3f3f3;
+    border-top: 8px solid #3498db;
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 10px;
+}
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/subset-client.html
+++ b/subset-client.html
@@ -25,6 +25,7 @@
     </script>
 </head>
 <body>
+<div id="loading"><div class="spinner"></div>Loading dataset...</div>
 <div class="container my-4">
 <h1>Explore-wrongthink</h1>
 <form id="filterForm" class="mb-4">
@@ -61,6 +62,7 @@
 </tbody>
 </table>
 </div>
+<div id="charts" style="display:none">
 <h2>Single category counts</h2>
 <canvas id="singleChart"></canvas>
 <h2>Pairwise co-occurrences</h2>
@@ -69,6 +71,7 @@
 <canvas id="comboChart"></canvas>
 <h2>Word Cloud</h2>
 <canvas id="wordCloud"></canvas>
+</div>
 <script src="dataset.js"></script>
 <script>
 const checkboxLabelMapping = {


### PR DESCRIPTION
## Summary
- add loader/spinner CSS back
- show a loading message and wrap charts in `#charts`

## Testing
- `python -m py_compile $(git ls-files '*.py')`