### PR TITLE
Automatically update subsets on filter changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ First convert the moderation dataset to `dataset.js`:
 ```
 python scripts/jsonl_to_js.py --input samples-1680.jsonl --output dataset.js
 ```
-Then open `subset-client.html` in your web browser. Select your desired values and click **Generate subset**. For example, an input of "V" (violence) + "SH" (self-harm) parameters as 1, with all others being 0, gives two prompts:
+Then open `subset-client.html` in your web browser. Select your desired values—results update automatically whenever you change a classification option. For example, an input of "V" (violence) + "SH" (self-harm) parameters as 1, with all others being 0, gives two prompts:
 
-![Screenshot of violence+self-harm combination subset of prompts.](EW_example_V+SH.png "Select your desired values and click on 'Generate subset'")
+![Screenshot of violence+self-harm combination subset of prompts.](EW_example_V+SH.png "Results update automatically when you change classifications")
 
 Below is a histogram showing how frequently each label combination appears in the dataset.
 

--- a/subset-client.html
+++ b/subset-client.html
@@ -122,7 +122,9 @@ function getRowValue(row, key) {
 
 
 function generateSubset(event) {
-    event.preventDefault();
+    if (event) {
+        event.preventDefault();
+    }
     const formData = new FormData(document.getElementById('filterForm'));
     const values = {};
     checkboxes.forEach(cb => {
@@ -160,6 +162,7 @@ function generateSubset(event) {
 
 document.getElementById('filterForm').addEventListener('submit', generateSubset);
 buildFilterTable();
+document.getElementById('filterForm').addEventListener('change', generateSubset);
 
 const KEYS = CATEGORY_KEYS;
 
@@ -444,6 +447,7 @@ datasetPromise.then(() => {
     safeExecute('pairwise heatmap', () => drawPairwiseHeatmap(pairCounts));
     safeExecute('combination chart', () => drawCombinationChart(comboCounts));
     updateWordCloudForCategory('All');
+    generateSubset();
 }).catch(err => {
     const loading = document.getElementById('loading');
     if (loading) loading.textContent = 'Error loading dataset: ' + (err.message || err);


### PR DESCRIPTION
## Summary
- update `generateSubset` to accept optional event
- attach change listener to radio button form
- build initial subset when the dataset loads
- document that subsets refresh automatically

## Testing
- `pytest -q` *(fails: command not found)*