### PR TITLE
Improve subset table UX

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,3 +8,7 @@ table {
 th, td {
     word-wrap: break-word;
 }
+
+.category-label {
+    cursor: pointer;
+}

--- a/subset-client.html
+++ b/subset-client.html
@@ -52,10 +52,7 @@
 <table class="table table-bordered table-sm" id="results">
     <thead>
         <tr>
-            <th>Prompt</th>
-            <th>Value = 0</th>
-            <th>Value = 1</th>
-            <th>Value = N/A</th>
+            <th>Prompt <small class="text-muted">(hover for classifications)</small></th>
         </tr>
     </thead>
     <tbody>
@@ -97,18 +94,20 @@ function setAllRadioButtons(value) {
             radio.checked = true;
         }
     });
+    generateSubset();
 }
 
 function buildFilterTable() {
     const tbody = document.getElementById('filterBody');
     checkboxes.forEach(cb => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td><label>${checkboxLabelMapping[cb]}</label></td>` +
-            `<td><input type="radio" name="radio-${cb}" value="0">0</td>` +
-            `<td><input type="radio" name="radio-${cb}" value="1">1</td>` +
-            `<td><input type="radio" name="radio-${cb}" value="Any" checked>Any</td>` +
-            `<td><input type="radio" name="radio-${cb}" value="0 or N/A">0 or N/A</td>` +
-            `<td>N/A</td>`;
+        tr.innerHTML =
+            `<td><label for="radio-${cb}-1" class="category-label">${checkboxLabelMapping[cb]}</label></td>` +
+            `<td><input id="radio-${cb}-0" type="radio" name="radio-${cb}" value="0">0</td>` +
+            `<td><input id="radio-${cb}-1" type="radio" name="radio-${cb}" value="1">1</td>` +
+            `<td><input id="radio-${cb}-any" type="radio" name="radio-${cb}" value="Any" checked>Any</td>` +
+            `<td><input id="radio-${cb}-na" type="radio" name="radio-${cb}" value="0 or N/A">0 or N/A</td>` +
+            `<td class="last-value">N/A</td>`;
         tbody.appendChild(tr);
     });
 }
@@ -155,7 +154,14 @@ function generateSubset(event) {
     tbody.innerHTML = '';
     results.forEach(row => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${row.prompt}</td><td>${row.keys_0}</td><td>${row.keys_1}</td><td>${row.keys_na}</td>`;
+        const td = document.createElement('td');
+        const info = [];
+        if (row.keys_1) info.push(`1: ${row.keys_1}`);
+        if (row.keys_0) info.push(`0: ${row.keys_0}`);
+        if (row.keys_na) info.push(`N/A: ${row.keys_na}`);
+        td.textContent = row.prompt;
+        if (info.length) td.title = info.join(' | ');
+        tr.appendChild(td);
         tbody.appendChild(tr);
     });
 }


### PR DESCRIPTION
## Summary
- make category labels clickable
- display classification results as tooltips so prompts use more space
- refresh subset when using "Set all values" buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`