### PR TITLE
Implement tri-state classification filter

### DIFF
--- a/subset-client.html
+++ b/subset-client.html
@@ -34,10 +34,7 @@
     <thead>
         <tr>
             <th>Classification key</th>
-            <th>0</th>
-            <th>1</th>
-            <th>Any</th>
-            <th>0 or N/A</th>
+            <th>Filter</th>
         </tr>
     </thead>
     <tbody id="filterBody">
@@ -92,13 +89,43 @@ function buildFilterTable() {
     checkboxes.forEach(cb => {
         const tr = document.createElement('tr');
         tr.innerHTML =
-            `<td><label for="radio-${cb}-1" class="category-label">${checkboxLabelMapping[cb]}</label></td>` +
-            `<td><input id="radio-${cb}-0" type="radio" name="radio-${cb}" value="0">0</td>` +
-            `<td><input id="radio-${cb}-1" type="radio" name="radio-${cb}" value="1">1</td>` +
-            `<td><input id="radio-${cb}-any" type="radio" name="radio-${cb}" value="Any" checked>Any</td>` +
-            `<td><input id="radio-${cb}-na" type="radio" name="radio-${cb}" value="0 or N/A">0 or N/A</td>`;
+            `<td><label for="tri-${cb}" class="category-label">${checkboxLabelMapping[cb]}</label></td>` +
+            `<td><input id="tri-${cb}" type="checkbox" class="tristate" data-state="Any"><span class="ms-1 state-label" id="tri-${cb}-label">Any</span></td>`;
         tbody.appendChild(tr);
     });
+    tbody.querySelectorAll('.tristate').forEach(initTriState);
+}
+
+function initTriState(input) {
+    const label = document.getElementById(`${input.id}-label`);
+    function update() {
+        const state = input.dataset.state;
+        if (state === 'Include') {
+            input.checked = true;
+            input.indeterminate = false;
+            if (label) label.textContent = 'Include';
+        } else if (state === 'Exclude') {
+            input.checked = false;
+            input.indeterminate = false;
+            if (label) label.textContent = 'Exclude';
+        } else {
+            input.checked = false;
+            input.indeterminate = true;
+            if (label) label.textContent = 'Any';
+        }
+    }
+
+    input.addEventListener('click', e => {
+        e.preventDefault();
+        const state = input.dataset.state;
+        if (state === 'Any') input.dataset.state = 'Include';
+        else if (state === 'Include') input.dataset.state = 'Exclude';
+        else input.dataset.state = 'Any';
+        update();
+        document.getElementById('filterForm').dispatchEvent(new Event('change'));
+    });
+
+    update();
 }
 
 function getRowValue(row, key) {
@@ -113,17 +140,18 @@ function generateSubset(event) {
     if (event) {
         event.preventDefault();
     }
-    const formData = new FormData(document.getElementById('filterForm'));
     const values = {};
     checkboxes.forEach(cb => {
-        values[cb] = formData.get(`radio-${cb}`) || 'Any';
+        const el = document.getElementById(`tri-${cb}`);
+        values[cb] = el ? el.dataset.state || 'Any' : 'Any';
     });
     const results = dataset.filter(row => {
         return checkboxes.every(key => {
             const rowValue = getRowValue(row, key);
             const selected = values[key];
-            return selected === 'Any' || rowValue === selected ||
-                   (selected === '0 or N/A' && (rowValue === '0' || rowValue === 'N/A'));
+            if (selected === 'Include') return rowValue === '1';
+            if (selected === 'Exclude') return rowValue === '0';
+            return true; // Any
         });
     }).map(row => {
         const keys0 = [];


### PR DESCRIPTION
## Summary
- replace four radio buttons per classification with a single tri-state checkbox
- cycle between **Any**, **Include**, and **Exclude**
- update filtering logic to use the tri-state control

## Testing
- `python -m py_compile scripts/jsonl_to_js.py category_analysis.py combinations.py`