### PR TITLE
Add filter summary and remove roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,4 @@ Below is a histogram showing how frequently each label combination appears in th
 The client page now includes visualizations rendered with Chart.js. After generating `dataset.js`, open the page to see bar charts of single-category counts, a heatmap of pairwise co-occurrences, and a histogram of key combinations.
 If the charts do not appear, check the browser console for error messages.
 
-## What is EW's technology stack?
 
-EW relies mostly on a few simple Python scripts. The subset generator is a static HTML page powered by JavaScript and Chart.js.
-
-## Roadmap/wishlist
-
-### Subset generator
-* Client-side Javascript version that does not require Python (done)
-* Add more options: "N/A" ? "1 or N/A" ? Better way to organize them?
-* Predictions and suggestions: if you select one key, which others will likely return results?

--- a/subset-client.html
+++ b/subset-client.html
@@ -29,6 +29,7 @@
 <div class="container my-4">
 <h1>Explore-wrongthink</h1>
 <input type="text" id="searchQuery" class="form-control mb-3" placeholder="Search prompts…">
+<div id="filterSummary" class="mb-3"></div>
 <h2>Word Cloud</h2>
 <div class="mb-2">
   <label for="wordCategorySelect" class="form-label">Word Cloud Category</label>
@@ -179,6 +180,18 @@ function generateSubset(event) {
         const el = document.getElementById(`tri-${cb}`);
         values[cb] = el ? el.dataset.state || 'Any' : 'Any';
     });
+    const summaryParts = [];
+    checkboxes.forEach(cb => {
+        const state = values[cb];
+        if (state !== 'Any') {
+            summaryParts.push(`${cb}: ${state}`);
+        }
+    });
+    if (query) summaryParts.push(`search: "${query}"`);
+    const summaryEl = document.getElementById('filterSummary');
+    if (summaryEl) {
+        summaryEl.textContent = summaryParts.length ? summaryParts.join(', ') : 'No filters applied';
+    }
     updateSuggestionDisplay(values);
     const results = dataset.filter(row => {
         const match = checkboxes.every(key => {
@@ -217,6 +230,13 @@ function generateSubset(event) {
         tr.appendChild(td);
         tbody.appendChild(tr);
     });
+    if (results.length === 0) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.textContent = 'No results. Try relaxing the filters.';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    }
 }
 
 document.getElementById('filterForm').addEventListener('submit', generateSubset);


### PR DESCRIPTION
## Summary
- display active filters in new summary area
- show a message when no prompts match filters
- drop the technology stack and roadmap sections from the README

## Testing
- `python -m py_compile category_analysis.py combinations.py`
