### PR TITLE
Improve dataset load debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ then open `http://localhost:8000/` (or the port shown) in your browser, or use
 GitHub Pages to view the site. Using a regular HTTP(S) URL avoids the
 file-protocol restrictions that would otherwise keep "Loading dataset..." on the
 screen.
+
+The page also shows loading debug messages directly below the spinner. If the
+dataset fails to load, these messages will include HTTP status codes and other
+details to help diagnose the problem.

--- a/dataset-loader.js
+++ b/dataset-loader.js
@@ -1,5 +1,5 @@
 if (typeof window.appendLoadingDebug === 'function') {
-  appendLoadingDebug('dataset-loader.js executing');
+  appendLoadingDebug('dataset-loader.js executing (protocol ' + location.protocol + ')');
 }
 
 function handleError(err) {
@@ -15,16 +15,21 @@ function handleError(err) {
 if (location.protocol === 'file:') {
   handleError(new Error('Cannot fetch dataset.json when using file:// protocol'));
 } else {
+  appendLoadingDebug('Fetching dataset.json');
   fetch('dataset.json')
     .then(r => {
       if (typeof window.appendLoadingDebug === 'function') {
-        appendLoadingDebug('dataset.json fetched');
+        appendLoadingDebug('dataset.json HTTP status ' + r.status);
+      }
+      if (!r.ok) {
+        throw new Error('HTTP ' + r.status + ' ' + r.statusText);
       }
       return r.json();
     })
     .then(data => {
       if (typeof window.appendLoadingDebug === 'function') {
-        appendLoadingDebug('dataset.json parsed, length ' + (Array.isArray(data) ? data.length : '?'));
+        const len = Array.isArray(data) ? data.length : '?';
+        appendLoadingDebug('dataset.json parsed, length ' + len);
       }
       window.dataset = data;
       if (typeof window.datasetResolve === 'function') {

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <body>
 <div id="loading">
   <div class="spinner"></div>
-  <div id="loading-text">Loading dataset...</div>
+  <div id="loading-text">Loading dataset... <span class="text-muted">(debug messages below)</span></div>
   <div id="loading-debug" class="text-muted small"></div>
 </div>
 <div class="container my-4">
@@ -369,14 +369,14 @@ setTimeout(() => {
         appendLoadingDebug('Dataset still not loaded after 5s');
         const el = document.getElementById('loading-text');
         if (el && el.textContent.includes('Fetching')) {
-            el.textContent += ' (still loading, check console)';
+            el.textContent += ' (still loading, see debug or console)';
         }
     }
 }, 5000);
 
 setTimeout(() => {
     if (!datasetLoaded) {
-        updateLoadingText('Failed to load dataset. Check console.');
+        updateLoadingText('Failed to load dataset. See debug or console.');
         appendLoadingDebug('Dataset failed to load within 10s');
     }
 }, 10000);


### PR DESCRIPTION
## Summary
- add HTTP status logging when fetching dataset.json
- show protocol and dataset length in debug messages
- update loading text to reference debug area
- note availability of debug messages in README

## Testing
- `node -e "require('./dataset-loader.js');"` *(fails: window is not defined)*