### PR TITLE
Handle file protocol dataset load

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,12 @@ The chart on the left counts prompts for each single category, the heatmap in th
 
 If the charts do not appear, check the browser console for error messages.
 
-If you open `index.html` directly from your filesystem and the page is stuck on
-"Loading dataset...", your browser is blocking local file requests. Serve the
-directory with a small web server (for example `python3 -m http.server`) and
-then open `http://localhost:8000/` (or the port shown) in your browser, or use
-GitHub Pages to view the site. Using a regular HTTP(S) URL avoids the
-file-protocol restrictions that would otherwise keep "Loading dataset..." on the
-screen.
+If you open `index.html` directly from your filesystem, the page now loads
+`dataset.js` via a script tag. This avoids the file-protocol restrictions that
+previously kept "Loading dataset..." on the screen. When served over an HTTP(S)
+URL the page instead fetches `dataset.json`. You can still run a local server
+(for example `python3 -m http.server`) if you prefer, but it is no longer
+required for basic usage.
 
 The page also shows loading debug messages directly below the spinner. These now
 include numbered steps (1–5) describing each part of the loading process. If the

--- a/dataset-loader.js
+++ b/dataset-loader.js
@@ -13,7 +13,23 @@ function handleError(err) {
 }
 
 if (location.protocol === 'file:') {
-  handleError(new Error('Cannot fetch dataset.json when using file:// protocol'));
+  appendLoadingDebug('Step 4/5: Loading dataset.js');
+  const script = document.createElement('script');
+  script.src = 'dataset.js';
+  script.onload = () => {
+    if (typeof window.appendLoadingDebug === 'function') {
+      const len = Array.isArray(dataset) ? dataset.length : '?';
+      appendLoadingDebug('Step 5/5: dataset.js loaded, length ' + len);
+    }
+    window.dataset = dataset;
+    if (typeof window.datasetResolve === 'function') {
+      window.datasetResolve();
+    }
+  };
+  script.onerror = err => {
+    handleError(err);
+  };
+  document.head.appendChild(script);
 } else {
   appendLoadingDebug('Step 4/5: Fetching dataset.json');
   fetch('dataset.json')


### PR DESCRIPTION
## Summary
- support loading `dataset.js` when opening the page via `file:` URLs
- update usage docs for local browsing without a server

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: command not found)*