### PR TITLE
Fix layout for zoom and filter columns

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -70,18 +70,23 @@ mark {
 /* Layout for zoom slider and filter table */
 #controlsRow {
     display: flex;
-    flex-direction: column;
     gap: 1rem;
     padding: 0.5rem 0;
+    align-items: flex-start;
 }
-@media (min-width: 768px) {
-    #controlsRow {
-        flex-direction: row;
-        align-items: flex-start;
-    }
+
+#zoomBox {
+    flex: 0 0 25%;
+    min-width: 200px;
 }
+
+#filterBox {
+    flex: 1 1 75%;
+}
+
 .zoom-control {
-    max-width: 260px;
+    width: 100%;
+    max-width: none;
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- make the controls row a permanent flex row
- size zoom column at 25% with a min-width
- let the filter table expand to the remaining width

## Testing
- `git status --short`